### PR TITLE
moving version string to setup.py so that it will install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from os.path import join, dirname, exists
 from setuptools import setup
 from setuptools import find_packages
 
-from ssh_config import __version__
 long_description = open(join(dirname(__file__), 'README.md')).read().strip() if exists('README.md') else ''
 install_requires = [
     "pyparsing",
@@ -12,6 +11,8 @@ install_requires = [
     "texttable",
     "Jinja2",
 ]
+
+__version__ = ".".join(map(str, (0, 0, 12)))
 
 setup(
     name="ssh_config",

--- a/ssh_config/__init__.py
+++ b/ssh_config/__init__.py
@@ -1,5 +1,3 @@
 from .client import SSHConfig, Host, EmptySSHConfig
 
-__version__ = ".".join(map(str, (0, 0, 12)))
-
 __all__ = ["EmptySSHConfig", "SSHConfig", "Host"]


### PR DESCRIPTION
Fixes #6 

I'm not sure if there was a strong intent behind having the `__version__` string in `client/__init__.py` but this will be just as maintainable since it is not doing any real processing on the version string, maybe it would be ok. 

I have also used a `__meta__.py` file pattern in some cases to keep it out of the `setup.py` if you prefer.