### PR TITLE
Full canonical options.

### DIFF
--- a/ssh_config/client.py
+++ b/ssh_config/client.py
@@ -67,8 +67,11 @@ class Host(object):
         ("Match", str),
         ("AddKeysToAgent", str),
         ("BindInterface", str),
-        ("CanonialDomains", str),
-        ("CnonicalizeFallbackLocal", str),
+        ("CanonicalizeHostname", str), # yes, no
+        ("CanonicalizeMaxDots", int),
+        ("CanonicalDomains", str),
+        ("CanonicalizePermittedCNAMEs", str),
+        ("CanonicalizeFallbackLocal", str),
         ("IdentityAgent", str),
         ("PreferredAuthentications", str),
         ("ServerAliveInterval", int),


### PR DESCRIPTION
All canonical options for ssh config files, please see http://blog.djm.net.au/2014/01/hostname-canonicalisation-in-openssh.html