### PR TITLE
feat: automatically find existing `IdentityFile`

### DIFF
--- a/ssh_config/cli.py
+++ b/ssh_config/cli.py
@@ -77,7 +77,7 @@ def get_identity_files(path: str = "~/.ssh"):
             keys.append(os.path.join(path, file))
     if len(keys) == 0:
         # keys not found, return default key
-        print(f"[Warning] identity file not found, using default")
+        click.echo(f"[Warning] identity file not found, using default")
         return os.path.join(path, "id_rsa")
     elif len(keys) == 1:
         return keys[0]


### PR DESCRIPTION
Find existing keys in the default SSH config path and it can save some time if one doesn't have `id_rsa` key